### PR TITLE
Fix #6: Show GitHub handles when a gallery cell is active

### DIFF
--- a/src/components/Gallery/ContributorGalleryCell.tsx
+++ b/src/components/Gallery/ContributorGalleryCell.tsx
@@ -11,10 +11,13 @@ export default function ContributorGalleryCell({
   cell,
 }: ContributorGalleryCellProps): JSX.Element {
   const cellContent = cell.contributor ? (
-    <FittedImage
-      src={cell.contributor.avatar_url}
-      {...cell}
-    />
+    <>
+      <FittedImage
+        src={cell.contributor.avatar_url}
+        {...cell}
+      />
+      {cell.isActive && <LoginText>{cell.contributor.login}</LoginText>}
+    </>
   ) : null;
 
   return <Cell>{cellContent}</Cell>;
@@ -41,4 +44,13 @@ const FittedImage = styled.img<MatrixCell & ThemeProps>`
   transition: transform 2s ease;
   z-index: ${({ isActive }) =>
     isActive ? 10 : 1};
+`;
+
+const LoginText = styled.span<ThemeProps>`
+  font-size: ${cellSize};
+  color: gold;
+  text-shadow: 2px 2px black;
+  text-align: center;
+  position: absolute;
+  z-index: 12;
 `;


### PR DESCRIPTION
Fixes #6

Show GitHub handles when a gallery cell is active

This PR was created with Copilot Workspace (v0.11). For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/lostintangent/contributor-gallery/issues/6?shareId=d0d258a5-1f1d-4685-bb2d-e992ec94442b).