### PR TITLE
Fix #6: Show GitHub handles when a gallery cell is active

### DIFF
--- a/src/components/Gallery/ContributorGalleryCell.tsx
+++ b/src/components/Gallery/ContributorGalleryCell.tsx
@@ -11,10 +11,13 @@ export default function ContributorGalleryCell({
   cell,
 }: ContributorGalleryCellProps): JSX.Element {
   const cellContent = cell.contributor ? (
-    <FittedImage
-      src={cell.contributor.avatar_url}
-      {...cell}
-    />
+    <>
+      <FittedImage
+        src={cell.contributor.avatar_url}
+        {...cell}
+      />
+      {cell.isActive ? <LoginText login={cell.contributor.login} /> : null}
+    </>
   ) : null;
 
   return <Cell>{cellContent}</Cell>;
@@ -41,4 +44,12 @@ const FittedImage = styled.img<MatrixCell & ThemeProps>`
   transition: transform 2s ease;
   z-index: ${({ isActive }) =>
     isActive ? 10 : 1};
+`;
+
+const LoginText = styled.span<{ login: string } & ThemeProps>`
+  color: gold;
+  font-size: ${cellSize};
+  position: absolute;
+  text-shadow: 1px 1px 1px black;
+  z-index: 10;
 `;


### PR DESCRIPTION
Fixes #6

Show GitHub handles when a gallery cell is active

This PR was created with Copilot Workspace (v0.14). For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/lostintangent/contributor-gallery/issues/6?shareId=67053aff-8e4f-42e7-be14-df3aaf80cdf5).