### PR TITLE
Display GitHub handle on active gallery cells

### DIFF
--- a/src/components/Gallery/ContributorGalleryCell.tsx
+++ b/src/components/Gallery/ContributorGalleryCell.tsx
@@ -11,10 +11,13 @@ export default function ContributorGalleryCell({
   cell,
 }: ContributorGalleryCellProps): JSX.Element {
   const cellContent = cell.contributor ? (
-    <FittedImage
-      src={cell.contributor.avatar_url}
-      {...cell}
-    />
+    <>
+      <FittedImage
+        src={cell.contributor.avatar_url}
+        {...cell}
+      />
+      {cell.isActive && <LoginText>{cell.contributor.login}</LoginText>}
+    </>
   ) : null;
 
   return <Cell>{cellContent}</Cell>;
@@ -41,4 +44,15 @@ const FittedImage = styled.img<MatrixCell & ThemeProps>`
   transition: transform 2s ease;
   z-index: ${({ isActive }) =>
     isActive ? 10 : 1};
+`;
+
+const LoginText = styled.span<ThemeProps>`
+  color: ${({ theme: { specialColor } }) => specialColor};
+  font-size: ${({ theme: { cellSize } }) => cellSize};
+  position: absolute;
+  text-shadow: 1px 1px 3px black;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 11;
 `;


### PR DESCRIPTION
This pull request improves the contributor gallery experience by displaying the GitHub handle of the developer that is currently active. The handle is displayed using a text shadow and gold font, and is properly positioned above the user's avatar image. 

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/lostintangent/contributor-gallery/issues/6?shareId=300e715b-96bd-430b-a2d1-ce2669d595f9).