### PR TITLE
Display GitHub handle on active gallery cells

### DIFF
--- a/src/components/Gallery/ContributorGalleryCell.tsx
+++ b/src/components/Gallery/ContributorGalleryCell.tsx
@@ -11,10 +11,13 @@ export default function ContributorGalleryCell({
   cell,
 }: ContributorGalleryCellProps): JSX.Element {
   const cellContent = cell.contributor ? (
-    <FittedImage
-      src={cell.contributor.avatar_url}
-      {...cell}
-    />
+    <>
+      <FittedImage
+        src={cell.contributor.avatar_url}
+        {...cell}
+      />
+      {cell.isActive && <LoginText>{cell.contributor.login}</LoginText>}
+    </>
   ) : null;
 
   return <Cell>{cellContent}</Cell>;
@@ -41,4 +44,15 @@ const FittedImage = styled.img<MatrixCell & ThemeProps>`
   transition: transform 2s ease;
   z-index: ${({ isActive }) =>
     isActive ? 10 : 1};
+`;
+
+const LoginText = styled.div<ThemeProps>`
+  color: ${({ theme }) => theme.specialColor};
+  font-size: ${({ theme }) => theme.cellSize};
+  position: absolute;
+  text-shadow: 1px 1px 2px black;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 11;
 `;


### PR DESCRIPTION
Fixes #6

This pull request introduces a feature enhancement to the ContributorGalleryCell component within the `src/components/Gallery/ContributorGalleryCell.tsx` file. The update ensures that when a gallery cell is active, not only does it expand and receive a purple border, but it also displays the contributor's GitHub handle on top of their avatar. 

This is achieved by conditionally rendering a new styled component, `LoginText`, which is styled to appear above the avatar image when the cell is active. The GitHub handle text is made to stand out by setting its color to gold (referred to as `specialColor` in the theme), applying a black text shadow for better visibility, and centering it above the avatar. 
Additionally, the z-index of the GitHub handle text is set to 11, ensuring it overlays the avatar image as intended. This enhancement aligns with the initial issue's request for a more informative and visually appealing active gallery cell state.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/lostintangent/contributor-gallery/issues/6?shareId=8f71dd0f-f082-4a1e-886c-9d7e9d98e712).