### PR TITLE
Display GitHub handle on active gallery cells

### DIFF
--- a/src/components/Gallery/ContributorGalleryCell.tsx
+++ b/src/components/Gallery/ContributorGalleryCell.tsx
@@ -11,10 +11,13 @@ export default function ContributorGalleryCell({
   cell,
 }: ContributorGalleryCellProps): JSX.Element {
   const cellContent = cell.contributor ? (
-    <FittedImage
-      src={cell.contributor.avatar_url}
-      {...cell}
-    />
+    <>
+      <GitHubHandle isActive={cell.isActive}>{cell.contributor.login}</GitHubHandle>
+      <FittedImage
+        src={cell.contributor.avatar_url}
+        {...cell}
+      />
+    </>
   ) : null;
 
   return <Cell>{cellContent}</Cell>;
@@ -29,6 +32,19 @@ const Cell = styled.div<ThemeProps>`
   height: ${cellSize};
   position: relative;
   width: ${cellSize};
+`;
+
+const GitHubHandle = styled.div<{ isActive?: boolean } & ThemeProps>`
+  color: ${({ theme }) => theme.specialColor};
+  display: ${({ isActive }) => (isActive ? 'block' : 'none')};
+
+  font-size: ${({ theme }) => theme.cellSize};
+  position: absolute;
+  text-align: center;
+  text-shadow: 1px 1px 0px #000, -1px -1px 0px #000, 1px -1px 0px #000, -1px 1px 0px #000;
+  top: 0;
+  width: 100%;
+  z-index: 11;
 `;
 
 const FittedImage = styled.img<MatrixCell & ThemeProps>`


### PR DESCRIPTION
Related to #6

Implements the display of GitHub handles on active gallery cells, enhancing the contributor gallery's interactivity and visual appeal.

- **Adds conditional rendering** for the GitHub handle within `ContributorGalleryCell.tsx`, making the handle visible only when the cell is active.
- **Introduces a new styled component `GitHubHandle`** to style the GitHub handle text, including centering, applying a black text shadow, and setting the `z-index` to 11 to ensure it appears above the avatar image.
- **Adjusts the GitHub handle's font color** to gold, aligning with the theme's special color setting for enhanced visibility and aesthetic consistency.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/lostintangent/contributor-gallery/issues/6?shareId=3754d0c6-4c7e-443b-84d9-5a245caeac65).