### PR TITLE
Display GitHub handle on active gallery cells

### DIFF
--- a/src/components/Gallery/ContributorGalleryCell.tsx
+++ b/src/components/Gallery/ContributorGalleryCell.tsx
@@ -11,10 +11,13 @@ export default function ContributorGalleryCell({
   cell,
 }: ContributorGalleryCellProps): JSX.Element {
   const cellContent = cell.contributor ? (
-    <FittedImage
-      src={cell.contributor.avatar_url}
-      {...cell}
-    />
+    <>
+      <GitHubHandle isActive={cell.isActive}>{cell.contributor.login}</GitHubHandle>
+      <FittedImage
+        src={cell.contributor.avatar_url}
+        {...cell}
+      />
+    </>
   ) : null;
 
   return <Cell>{cellContent}</Cell>;
@@ -29,6 +32,18 @@ const Cell = styled.div<ThemeProps>`
   height: ${cellSize};
   position: relative;
   width: ${cellSize};
+`;
+
+const GitHubHandle = styled.div<{ isActive?: boolean } & ThemeProps>`
+  color: ${({ theme }) => theme.specialColor};
+  display: ${({ isActive }) => (isActive ? "block" : "none")};
+  font-size: ${({ theme }) => theme.cellSize};
+  position: absolute;
+  text-align: center;
+  text-shadow: 1px 1px 0px #000, -1px -1px 0px #000, 1px -1px 0px #000, -1px 1px 0px #000;
+  top: 0;
+  width: 100%;
+  z-index: 12;
 `;
 
 const FittedImage = styled.img<MatrixCell & ThemeProps>`


### PR DESCRIPTION
Related to #6

This pull request introduces functionality to display a contributor's GitHub handle on their gallery cell when it is active, enhancing the visual feedback of the gallery.

- **GitHub Handle Display**: Adds a new styled component `GitHubHandle` that conditionally renders the contributor's GitHub handle text above their avatar when the gallery cell is active. This text is styled to be gold, centered, and with a black text shadow for better visibility.
- **Styling Adjustments**: Sets the z-index of the GitHub handle text to 12, ensuring it appears on top of the avatar image. The font size of the handle text is matched with the cell size theme property for consistency and readability.
- **Code Structure**: Implements conditional rendering within the `ContributorGalleryCell` component to include the GitHub handle text alongside the avatar image, wrapped in a React fragment for clean DOM structure.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/lostintangent/contributor-gallery/issues/6?shareId=5b8c8c65-115f-46b7-822a-200e78e28f20).