### PR TITLE
Display GitHub handle on active gallery cells

### DIFF
--- a/src/components/Gallery/ContributorGalleryCell.tsx
+++ b/src/components/Gallery/ContributorGalleryCell.tsx
@@ -11,10 +11,13 @@ export default function ContributorGalleryCell({
   cell,
 }: ContributorGalleryCellProps): JSX.Element {
   const cellContent = cell.contributor ? (
-    <FittedImage
-      src={cell.contributor.avatar_url}
-      {...cell}
-    />
+    <>
+      <GitHubHandle isActive={cell.isActive}>{cell.contributor.login}</GitHubHandle>
+      <FittedImage
+        src={cell.contributor.avatar_url}
+        {...cell}
+      />
+    </>
   ) : null;
 
   return <Cell>{cellContent}</Cell>;
@@ -29,6 +32,18 @@ const Cell = styled.div<ThemeProps>`
   height: ${cellSize};
   position: relative;
   width: ${cellSize};
+`;
+
+const GitHubHandle = styled.div<{ isActive?: boolean } & ThemeProps>`
+  color: blue;
+  display: ${({ isActive }) => (isActive ? 'block' : 'none')};
+  font-size: ${({ theme }) => theme.cellSize};
+  position: absolute;
+  text-align: center;
+  text-shadow: 1px 1px 0px #000;
+  top: 0;
+  width: 100%;
+  z-index: 11;
 `;
 
 const FittedImage = styled.img<MatrixCell & ThemeProps>`


### PR DESCRIPTION
Related to #6

Implements the display of GitHub handles on active gallery cells with styling adjustments.

- Adds a new `GitHubHandle` styled component to `ContributorGalleryCell.tsx` that conditionally renders based on the cell's active state.
- Sets the GitHub handle text to be displayed above the contributor's avatar when the cell is active.
- Styles the GitHub handle with a blue color, centered alignment, and a black text shadow for better visibility against the avatar background.
- Adjusts the `GitHubHandle` font size to match the theme's cell size, ensuring consistency across the gallery.
- Corrects the text color to blue, differing from the initial plan to use gold.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/lostintangent/contributor-gallery/issues/6?shareId=3b3333a1-3c32-45ea-9860-b42ef0f218d0).