### PR TITLE
Display GitHub handle on active gallery cell

### DIFF
--- a/src/components/Gallery/ContributorGalleryCell.tsx
+++ b/src/components/Gallery/ContributorGalleryCell.tsx
@@ -11,14 +11,28 @@ export default function ContributorGalleryCell({
   cell,
 }: ContributorGalleryCellProps): JSX.Element {
   const cellContent = cell.contributor ? (
-    <FittedImage
-      src={cell.contributor.avatar_url}
-      {...cell}
-    />
+    <>
+      <GitHubHandle isActive={cell.isActive}>{cell.contributor.login}</GitHubHandle>
+      <FittedImage
+        src={cell.contributor.avatar_url}
+        {...cell}
+      />
+    </>
   ) : null;
 
   return <Cell>{cellContent}</Cell>;
 }
+
+const GitHubHandle = styled.div<{ isActive?: boolean } & ThemeProps>`
+  color: ${() => "black"};
+  display: ${({ isActive }) => (isActive ? "block" : "none")};
+  font-size: ${({ theme }) => theme.cellSize};
+  position: absolute;
+  text-align: center;
+  text-shadow: 1px 1px 2px black;
+  width: 100%;
+  z-index: 11;
+`;
 
 const borderStyle = ({ theme: { borderStyle } }: ThemeProps) => borderStyle;
 const cellSize = ({ theme: { cellSize } }: ThemeProps) => cellSize;


### PR DESCRIPTION
Fixes to #6

Implements the display of GitHub handles on active gallery cells to enhance user identification.

- Adds a new styled component `GitHubHandle` to display the contributor's GitHub handle when a gallery cell is active. This component is conditionally rendered based on the cell's active state.
- Sets the font size of the `GitHubHandle` text to match the cell size theme property, ensuring consistency with the gallery's design.
- Applies a black text shadow to the `GitHubHandle` text for improved readability against the avatar image background.
- Centers the `GitHubHandle` text and sets its z-index to 11, making it appear on top of the avatar image as intended.
- Modifies the `ContributorGalleryCell` component to include the `GitHubHandle` component, displaying the GitHub handle on top of the contributor's avatar when the cell is active.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace-staging.githubnext.com/lostintangent/contributor-gallery/issues/6?shareId=d5f4b246-075b-4c67-818c-5591d3cf395e).