### PR TITLE
Show GitHub handles when a gallery cell is active

### DIFF
--- a/src/components/Gallery/ContributorGalleryCell.tsx
+++ b/src/components/Gallery/ContributorGalleryCell.tsx
@@ -11,10 +11,13 @@ export default function ContributorGalleryCell({
   cell,
 }: ContributorGalleryCellProps): JSX.Element {
   const cellContent = cell.contributor ? (
-    <FittedImage
-      src={cell.contributor.avatar_url}
-      {...cell}
-    />
+    <>
+      <FittedImage
+        src={cell.contributor.avatar_url}
+        {...cell}
+      />
+      {cell.isActive && <LoginText>{cell.contributor.login}</LoginText>}
+    </>
   ) : null;
 
   return <Cell>{cellContent}</Cell>;
@@ -41,4 +44,16 @@ const FittedImage = styled.img<MatrixCell & ThemeProps>`
   transition: transform 2s ease;
   z-index: ${({ isActive }) =>
     isActive ? 10 : 1};
+`;
+
+const LoginText = styled.div<ThemeProps>`
+  color: white;
+  font-size: ${cellSize};
+  position: absolute;
+  text-align: center;
+  text-shadow: 1px 1px 2px black;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 100%;
+  z-index: 11;
 `;


### PR DESCRIPTION
Fixes #6

Add GitHub handle display when a gallery cell is active.

* Define a new styled component `LoginText` for the login text.
* Set the font size of `LoginText` to the value of the `cellSize` theme property.
* Set the text shadow of `LoginText` to black.
* Conditionally display `LoginText` when the cell is active.
* Center `LoginText` and set its z-index to 11.
* Update `ContributorGalleryCell` component to include `LoginText` as a sibling of the avatar image component.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace-dev.githubnext.com/lostintangent/contributor-gallery/issues/6?shareId=3d828e59-1dff-462f-88a3-97f05cbf346a).