### PR TITLE
Show GitHub handles when a gallery cell is active

### DIFF
--- a/src/components/Gallery/ContributorGalleryCell.tsx
+++ b/src/components/Gallery/ContributorGalleryCell.tsx
@@ -47,7 +47,7 @@ const FittedImage = styled.img<MatrixCell & ThemeProps>`
 `;
 
 const LoginText = styled.span<ThemeProps>`
-  color: blue;
+  color: green;
   font-size: ${cellSize};
   position: absolute;
   text-align: center;

--- a/src/components/Gallery/ContributorGalleryCell.tsx
+++ b/src/components/Gallery/ContributorGalleryCell.tsx
@@ -11,10 +11,13 @@ export default function ContributorGalleryCell({
   cell,
 }: ContributorGalleryCellProps): JSX.Element {
   const cellContent = cell.contributor ? (
-    <FittedImage
-      src={cell.contributor.avatar_url}
-      {...cell}
-    />
+    <>
+      <FittedImage
+        src={cell.contributor.avatar_url}
+        {...cell}
+      />
+      {cell.isActive && <LoginText>{cell.contributor.login}</LoginText>}
+    </>
   ) : null;
 
   return <Cell>{cellContent}</Cell>;
@@ -41,4 +44,16 @@ const FittedImage = styled.img<MatrixCell & ThemeProps>`
   transition: transform 2s ease;
   z-index: ${({ isActive }) =>
     isActive ? 10 : 1};
+`;
+
+const LoginText = styled.span<ThemeProps>`
+  color: blue;
+  font-size: ${cellSize};
+  position: absolute;
+  text-align: center;
+  text-shadow: 1px 1px 2px black;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 100%;
+  z-index: 11;
 `;


### PR DESCRIPTION
Related to #6

Add GitHub handle display on active gallery cell.

* Define a new styled component `LoginText` as a sibling of the avatar image component.
* Conditionally display the `LoginText` when the cell is active.
* Set the font size of the `LoginText` to the value of the `cellSize` theme property.
* Render a black text shadow around the `LoginText`.
* Center the `LoginText` and set its z-index to 11.
* Set the font color of the `LoginText` to blue.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace-staging.githubnext.com/lostintangent/contributor-gallery/issues/6?shareId=08f43ab3-8485-426b-9458-a72a3c367a7d).